### PR TITLE
Add cancellation preview call wrapper

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -62,6 +62,9 @@ component subscriptions and discount subscriptions</p>
 <dt><a href="#getContractSelfServiceToken">getContractSelfServiceToken(contractId)</a></dt>
 <dd><p>Retrieve a short-lived selfservice access token</p>
 </dd>
+<dt><a href="#getContractCancellationPreview">getContractCancellationPreview(contractId)</a></dt>
+<dd><p>Retrieves a cancellation preview for a contract for a regular cancellation, considering contract and notice periods of the booked PlanVariant.</p>
+</dd>
 <dt><a href="#endContract">endContract(contractId, data)</a></dt>
 <dd><p>Set an enddate for this contract</p>
 </dd>

--- a/src/index.js
+++ b/src/index.js
@@ -266,6 +266,15 @@ export default class BillwerkAPI {
     return this.call(`/Contracts/${contractId}/SelfServiceToken`, 'GET');
   }
 
+  // /Contracts/{contractId}/cancellationPreview
+  /**
+   * Retrieves a cancellation preview for a contract for a regular cancellation, considering contract and notice periods of the booked PlanVariant.
+   * @param {string} contractId Contract ID
+   */
+  getContractCancellationPreview(contractId) {
+      return this.call(`/Contracts/${contractId}/cancellationPreview`, 'GET');
+  }
+
   // /Contracts/{contractId}/end
   /**
    * Set an enddate for this contract

--- a/src/index.js
+++ b/src/index.js
@@ -268,11 +268,12 @@ export default class BillwerkAPI {
 
   // /Contracts/{contractId}/cancellationPreview
   /**
-   * Retrieves a cancellation preview for a contract for a regular cancellation, considering contract and notice periods of the booked PlanVariant.
+   * Retrieves a cancellation preview for a contract for a regular cancellation,
+   * considering contract and notice periods of the booked PlanVariant.
    * @param {string} contractId Contract ID
    */
   getContractCancellationPreview(contractId) {
-      return this.call(`/Contracts/${contractId}/cancellationPreview`, 'GET');
+    return this.call(`/Contracts/${contractId}/cancellationPreview`, 'GET');
   }
 
   // /Contracts/{contractId}/end


### PR DESCRIPTION
Hi @AxelDuenninger,

mir ist aufgefallen, dass der cancellationPreview-Call keinen Wrapper in dieser Library hat. Ich habe einfach mal einen eingefügt. Wie geht ihr mit Pull-Requests um? 🙃